### PR TITLE
Shift button to allow a second bank of sources

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,7 @@ switcher.on('rawCommand', cmd => {
 /* Panel button handlers */
 
 let programMode = false;
+let shiftMode = false;
 
 panel.on('down', keyIndex => {
     if (config.showKeyPresses) console.log(`Key ${keyIndex} pressed`);
@@ -152,6 +153,27 @@ panel.on('down', keyIndex => {
         case 'backlight_down':
             currentBrightness = Math.max(currentBrightness - 10, 0);
             panel.setBacklightIntensity(currentBrightness);
+            break;
+        case 'shift':
+            shiftMode = true;
+            setLEDForKeyMapping(mapping, null, null, shiftMode, false);
+            break;
+        case 'shift_toggle':
+            shiftMode = !shiftMode;
+            setLEDForKeyMapping(mapping, null, null, shiftMode, false);
+            break;
+    }
+});
+
+
+panel.on('up', keyIndex => {
+    
+    const mapping = keyMappings[keyIndex];
+    if (!mapping) return;
+
+    switch (mapping.function) {
+        case 'shift':
+            shiftMode = false;
             break;
     }
 });


### PR DESCRIPTION
To fully utilize my ATEM Television Studio with my XKeys24, I wanted to emulate the functionality of the hardware ATEM Control Panels, where a shift key swaps the representation of all sources to a 2nd layer.

This adds `shift` and `shift-toggle` as button options, and a universal `shiftMode` to track whether the shift function is activated. `shift` will only engage the shift functionality when held down, while `shift-toggle` will alternately engage and disengage the shift functionality when pressed.

I also added a `flashShiftedSources` option to the config, which when active, will cause an active source on the shift layer to flash to show it is active. Since this can be distracting, without this option, the buttons will remain blank when a shifted source is active.

To configure a button to have a shift source, the `shift-source` field is optionally added alongside the `source` field. For example:
``` 
{
            key: 29,
            function: 'source',
            source: 3010, // Media Player 1
            shift-source: 3020 // Media Player 2
        },
```


I should admit I'm no longer using this application regularly, but these changes were tested and working when I last was.